### PR TITLE
Adds new config parameter METAFLOW_S3_VERIFY_CERTIFICATE

### DIFF
--- a/metaflow/datastore/util/s3util.py
+++ b/metaflow/datastore/util/s3util.py
@@ -4,13 +4,13 @@ import time
 import sys
 
 from metaflow.exception import MetaflowException
-from metaflow.metaflow_config import get_authenticated_boto3_client, S3_ENDPOINT_URL
+from metaflow.metaflow_config import get_authenticated_boto3_client, S3_ENDPOINT_URL, S3_VERIFY_CERTIFICATE
 from botocore.exceptions import ClientError
 
 S3_NUM_RETRIES = 7
 
 def get_s3_client():
-    return get_authenticated_boto3_client('s3', { 'endpoint_url': S3_ENDPOINT_URL }), ClientError
+    return get_authenticated_boto3_client('s3', { 'endpoint_url': S3_ENDPOINT_URL, 'verify': S3_VERIFY_CERTIFICATE }), ClientError
 
 # decorator to retry functions that access S3
 def aws_retry(f):

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -59,6 +59,7 @@ DATATOOLS_S3ROOT = from_conf(
 
 # S3 endpoint url 
 S3_ENDPOINT_URL = from_conf('METAFLOW_S3_ENDPOINT_URL', None)
+S3_VERIFY_CERTIFICATE = from_conf('METAFLOW_S3_VERIFY_CERTIFICATE', None)
 
 ###
 # Datastore local cache


### PR DESCRIPTION
Adds new parameter for boto3 `verify (boolean/string)` (e.g. `verify=False` )
Reference: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client

This parameter allows to ignore the SSL certificate verification or to check the certificate with a `.pem` file CA cert bundle.